### PR TITLE
Added option to allow simple average of stack

### DIFF
--- a/Image/ImageMath.cs
+++ b/Image/ImageMath.cs
@@ -69,18 +69,26 @@ namespace NINA.Plugin.Livestack.Image {
 
                     var median = pixelValues.Median();
 
-                    float sum = 0;
-                    float count = 0;
-                    foreach (var pixel in pixelValues) {
-                        if (median - (median * lowerPercentile) <= pixel && pixel <= median + (median * upperPercentile)) {
-                            sum += pixel;
-                            count++;
-                        }
-                    }
-                    if (count == 0) {
-                        master[pixelIndex] = median;
+                    if (lowerPercentile == 0.0 && upperPercentile == 0.0) {
+                        // Simple average
+                        float sum = 0;
+                        for (int i = 0; i < pixelValues.Length; i++)
+                            sum += pixelValues[i];
+                        master[pixelIndex] = sum / pixelValues.Length;
                     } else {
-                        master[pixelIndex] = sum / count;
+                        float sum = 0;
+                        float count = 0;
+                        foreach (var pixel in pixelValues) {
+                            if (median - (median * lowerPercentile) <= pixel && pixel <= median + (median * upperPercentile)) {
+                                sum += pixel;
+                                count++;
+                            }
+                        }
+                        if (count == 0) {
+                            master[pixelIndex] = median;
+                        } else {
+                            master[pixelIndex] = sum / count;
+                        }
                     }
                 }
             }

--- a/Instructions/DataTemplate.xaml
+++ b/Instructions/DataTemplate.xaml
@@ -15,8 +15,14 @@
         <nina:SequenceBlockView>
             <nina:SequenceBlockView.SequenceItemContent>
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock VerticalAlignment="Center" Text="Wait for flat stack?" />
-                    <CheckBox Margin="5,0,0,0" IsChecked="{Binding WaitForStack, Mode=TwoWay}" />
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock VerticalAlignment="Center" Text="Wait for flat stack?" />
+                        <CheckBox Margin="5,0,0,0" IsChecked="{Binding WaitForStack, Mode=TwoWay}" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="8,0,0,0">
+                        <TextBlock VerticalAlignment="Center" Text="Percentile Rejection?" />
+                        <CheckBox Margin="5,0,0,0" IsChecked="{Binding Rejection, Mode=TwoWay}" />
+                    </StackPanel>
                 </StackPanel>
             </nina:SequenceBlockView.SequenceItemContent>
             <nina:SequenceBlockView.SequenceItemProgressContent>


### PR DESCRIPTION
Added option to allow simple average of taken flats.

![image](https://github.com/user-attachments/assets/8c2bf775-328a-4ce2-8466-607fb560964b)

Default is old behaviour (percentile rejection). 

If recection is off, it will simply stack without rejection. Example:
![image](https://github.com/user-attachments/assets/4c804ffb-18f2-400d-9aff-b6b210cd9e2a)
