### PR TITLE
Emit LiveStack StatusBroadcast message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ﻿# Livestack
 
+## 1.0.1.7
+- A broadcast on IMessageBroker will be sent with the topic "Livestack_LivestackDockable_StatusBroadcast" when the plugin's running status changes.
+
 ## 1.0.1.6
 - Calibration frames that no longer exist will automatically get removed from the profile
 

--- a/LivestackDockables/LivestackDockable.cs
+++ b/LivestackDockables/LivestackDockable.cs
@@ -535,20 +535,15 @@ namespace NINA.Plugin.Livestack.LivestackDockables {
         }
 
         public async Task OnMessageReceived(IMessage message) {
-            switch (message.Topic) {
-                case $"Livestack_LivestackDockable_StartLiveStack":
-                    if (LivestackMediator.LiveStackDockable.StartLiveStackCommand.IsRunning) {
-                        return;
-                    }
-                    await Application.Current.Dispatcher.BeginInvoke(() => StartLiveStackCommand.ExecuteAsync(null));
-                    break;
-                case $"Livestack_LivestackDockable_StopLiveStack":
-                    if (LivestackMediator.LiveStackDockable.StartLiveStackCommand.IsRunning) {
-                        await Application.Current.Dispatcher.BeginInvoke(() => LivestackMediator.LiveStackDockable.StartLiveStackCancelCommand.Execute(null));
-                    }
-                    break;
-                default:
-                    break;
+            if (message.Topic == $"Livestack_LivestackDockable_StartLiveStack") {
+                if (LivestackMediator.LiveStackDockable.StartLiveStackCommand.IsRunning) {
+                    return;
+                }
+                await Application.Current.Dispatcher.BeginInvoke(() => StartLiveStackCommand.ExecuteAsync(null));
+            } else if (message.Topic == $"Livestack_LivestackDockable_StopLiveStack") {
+                if (LivestackMediator.LiveStackDockable.StartLiveStackCommand.IsRunning) {
+                    await Application.Current.Dispatcher.BeginInvoke(() => LivestackMediator.LiveStackDockable.StartLiveStackCancelCommand.Execute(null));
+                }
             }
         }
     }


### PR DESCRIPTION
When we observe the LiveStack from ninaAPI we only receive StackUpdatedBroadcast messages, but is impossible to know that status of the LiveStack plugin. After this change, a new StatusBroadcast event will be emitted every time the plugin changes from stacking to stopped. This will allow to show the status of the Livestack plugin from remotes applications (I'm currently thinking about provide a richer UI to Touch-N-Stars)