### PR TITLE
Add live stack reset to discard the current stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Livestack
 
+## 1.2.0.0
+- Added a reset button to the live stack panel to throw away the current stack and start a new one
+    - The button is only shown while live stacking is running and asks for confirmation before resetting
+    - Resetting closes all stack tabs and releases their stack buffers, so the next accepted frame starts a new stack and becomes its alignment reference frame
+    - This makes it possible to recover from a bad first frame that was picked as alignment reference without having to restart live stacking
+- Stack mutations are now serialized so a reset can no longer interleave with a frame that is currently being stacked
+
 ## 1.1.3.0
 - Fixed live-stack alignment star selection when detector brightness metadata is unusable.
     - Alignment now falls back to valid detected star centroids when MaxBrightness is saturated, invalid, or NaN, instead of producing zero filtered stars.
-- Improved “not enough alignment stars” logging with reject-reason diagnostics for invalid position, outside frame, invalid brightness, saturated brightness, HFR outlier, and fallback candidate count.
+- Improved ï¿½not enough alignment starsï¿½ logging with reject-reason diagnostics for invalid position, outside frame, invalid brightness, saturated brightness, HFR outlier, and fallback candidate count.
 
 ## 1.1.2.0
 - Added more logging for failure cases

--- a/Image/LiveStackBag.cs
+++ b/Image/LiveStackBag.cs
@@ -67,6 +67,12 @@ namespace NINA.Plugin.Livestack.Image {
             ImageCount++;
         }
 
+        public void Reset() {
+            Stack = null;
+            ReferenceImageStars = null;
+            ImageCount = 0;
+        }
+
         public void ForcePushReference(ImageProperties properties, List<Accord.Point> referenceStars, float[] stack) {
             Properties = properties;
             ReferenceImageStars = referenceStars;

--- a/LivestackDockables/ColorCombinationTab.cs
+++ b/LivestackDockables/ColorCombinationTab.cs
@@ -140,6 +140,15 @@ namespace NINA.Plugin.Livestack.LivestackDockables {
                 await Task.Run(() => {
                     Locked = true;
                     try {
+                        if (red.Stack == null || green.Stack == null || blue.Stack == null) {
+                            // At least one channel has nothing stacked yet, so there is nothing to combine
+                            StackCountRed = red.StackCount;
+                            StackCountGreen = green.StackCount;
+                            StackCountBlue = blue.StackCount;
+                            StackImage = null;
+                            return;
+                        }
+
                         StackCountRed = red.StackCount;
                         StackCountGreen = green.StackCount;
                         StackCountBlue = blue.StackCount;
@@ -200,6 +209,14 @@ namespace NINA.Plugin.Livestack.LivestackDockables {
         }
 
         public void MarkDirty() {
+            NeedsRefresh = true;
+        }
+
+        public void ResetStack() {
+            StackCountRed = 0;
+            StackCountGreen = 0;
+            StackCountBlue = 0;
+            StackImage = null;
             NeedsRefresh = true;
         }
 

--- a/LivestackDockables/IStackTab.cs
+++ b/LivestackDockables/IStackTab.cs
@@ -12,5 +12,7 @@ namespace NINA.Plugin.Livestack.LivestackDockables {
         public string Filter { get; }
         public bool Locked { get; set; }
         public BitmapSource StackImage { get; }
+
+        void ResetStack();
     }
 }

--- a/LivestackDockables/LiveStackTab.cs
+++ b/LivestackDockables/LiveStackTab.cs
@@ -93,11 +93,23 @@ namespace NINA.Plugin.Livestack.LivestackDockables {
         public async Task Refresh(CancellationToken token) {
             try {
                 await Task.Run(() => {
+                    if (Stack == null) {
+                        // Nothing is stacked yet. This happens when the tab was created but its first frame got skipped before a reference was pushed
+                        StackImage = null;
+                        StackCount = bag.ImageCount;
+                        return;
+                    }
                     StackImage = Render(StretchFactor, BlackClipping, EnableBackgroundExtraction, BackgroundExtractionAmount, Downsample);
                     StackCount = bag.ImageCount;
                 }, token);
             } catch {
             }
+        }
+
+        public void ResetStack() {
+            bag.Reset();
+            StackCount = 0;
+            StackImage = null;
         }
 
         private BitmapSource Render(double stretchFactor, double blackClipping, bool enableBackgroundExtraction, double backgroundExtractionAmount, int downsample) {

--- a/LivestackDockables/LivestackDockable.cs
+++ b/LivestackDockables/LivestackDockable.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using NINA.Core.Enum;
 using NINA.Core.Model;
+using NINA.Core.MyMessageBox;
 using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
 using NINA.Core.Utility.WindowService;
@@ -107,6 +108,10 @@ namespace NINA.Plugin.Livestack.LivestackDockables {
         private readonly IWindowServiceFactory windowServiceFactory;
         private readonly ICameraMediator cameraMediator;
         private readonly IMessageBroker messageBroker;
+
+        // Serializes stack mutations so a manual reset can never interleave with a frame that is currently being stacked
+        private readonly SemaphoreSlim stackMutationLock = new SemaphoreSlim(1, 1);
+
         private Guid? stackSessionId = null;
 
         [RelayCommand(IncludeCancelCommand = true)]
@@ -175,6 +180,55 @@ namespace NINA.Plugin.Livestack.LivestackDockables {
                     LiveStackMemoryPressure.CompactAfterReleasingLargeBuffers("live stack stopped");
                 }
             });
+        }
+
+        [RelayCommand]
+        private async Task ResetStacks(CancellationToken token) {
+            var tabsToReset = Tabs.ToList();
+            if (tabsToReset.Count == 0) {
+                Notification.ShowInformation("Live Stack - There is no stack to reset");
+                return;
+            }
+
+            var confirmation = MyMessageBox.Show(
+                "This will throw away the current live stack and close all stack tabs." + Environment.NewLine
+                    + "The next accepted frame will start a new stack and become its alignment reference frame." + Environment.NewLine + Environment.NewLine
+                    + "Do you want to reset the stack?",
+                "Reset live stack",
+                MessageBoxButton.OKCancel,
+                MessageBoxResult.Cancel);
+
+            if (confirmation != MessageBoxResult.OK) {
+                return;
+            }
+
+            await stackMutationLock.WaitAsync(token);
+            try {
+                Logger.Info($"Live Stack reset on user request. Closing {tabsToReset.Count} stack tab(s) and releasing their stack buffers. The next accepted frame will start a new stack.");
+                SelectedTab = null;
+                Tabs.Clear();
+
+                // Release the large stack buffers explicitly instead of waiting for the removed tabs to become unreachable
+                foreach (var tab in tabsToReset) {
+                    tab.ResetStack();
+                }
+
+                if (stackSessionId.HasValue) {
+                    foreach (var tab in tabsToReset) {
+                        if (tab is ColorCombinationTab colorTab) {
+                            _ = messageBroker.Publish(new LivestackBroadcast(LiveStackBroadcastContent.Color(0, 0, 0, colorTab.Filter, colorTab.Target, null), stackSessionId.Value));
+                        } else {
+                            _ = messageBroker.Publish(new LivestackBroadcast(LiveStackBroadcastContent.Monochrome(0, tab.Filter, tab.Target, null), stackSessionId.Value));
+                        }
+                    }
+                }
+            } finally {
+                stackMutationLock.Release();
+            }
+
+            await Task.Run(() => LiveStackMemoryPressure.CompactAfterReleasingLargeBuffers("stacks reset"));
+            applicationStatusMediator.StatusUpdate(new ApplicationStatus() { Source = "Live Stack", Status = "Stack reset - waiting for first frame" });
+            Notification.ShowInformation("Live Stack - The stack has been reset. The next accepted frame will start a new stack.");
         }
 
         [RelayCommand]
@@ -530,9 +584,11 @@ namespace NINA.Plugin.Livestack.LivestackDockables {
         }
 
         private async Task StackItem(LiveStackItem item, CancellationToken token) {
-            var tab = GetOrCreateStackBag(item);
-            tab.Locked = true;
+            await stackMutationLock.WaitAsync(token);
+            LiveStackTab tab = null;
             try {
+                tab = GetOrCreateStackBag(item);
+                tab.Locked = true;
                 if (SelectedTab == null) {
                     SelectedTab = tab;
                 }
@@ -566,7 +622,10 @@ namespace NINA.Plugin.Livestack.LivestackDockables {
                     }
                 }
             } finally {
-                tab.Locked = false;
+                if (tab != null) {
+                    tab.Locked = false;
+                }
+                stackMutationLock.Release();
             }
         }
 

--- a/LivestackDockables/LivestackDockableTemplates.xaml
+++ b/LivestackDockables/LivestackDockableTemplates.xaml
@@ -32,6 +32,7 @@
                                 <ColumnDefinition />
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBlock
                                 HorizontalAlignment="Left"
@@ -58,6 +59,27 @@
                                 CancelButtonImage="{DynamicResource StopSVG}"
                                 CancelCommand="{Binding StartLiveStackCancelCommand}"
                                 Command="{Binding StartLiveStackCommand}" />
+                            <Button
+                                Grid.Column="3"
+                                Width="50"
+                                Height="25"
+                                Margin="5,6,0,6"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Bottom"
+                                Command="{Binding ResetStacksCommand}"
+                                Visibility="{Binding StartLiveStackCommand.IsRunning, Converter={StaticResource VisibilityConverter}}">
+                                <Button.ToolTip>
+                                    <ToolTip ToolTipService.ShowOnDisabled="True">
+                                        <TextBlock Text="Reset the stack - discards all accumulated stack data and uses the next accepted frame as new reference frame" />
+                                    </ToolTip>
+                                </Button.ToolTip>
+                                <Path
+                                    Margin="5"
+                                    Data="{StaticResource TrashCanOpenSVG}"
+                                    Fill="{StaticResource ButtonForegroundBrush}"
+                                    Stretch="Uniform"
+                                    UseLayoutRounding="True" />
+                            </Button>
                         </Grid>
                     </Expander.Header>
                     <Grid>


### PR DESCRIPTION
## Problem

The first accepted frame becomes the permanent alignment reference (`ForcePushReference`), and `LiveStackBag.Stack` is a running average keyed on `ImageCount`. If that first frame is bad - trailed, off-target, captured while the mount was still settling - it poisons the reference and the accumulator for the rest of the session: later frames either fail affine alignment and get skipped, or fit a poor transform and smear the result.

Until now the only way out was to stop and restart live stacking, or remove every stack tab by hand.

## Solution

A reset button in the live stack panel header:

- shown only while live stacking is running
- asks for confirmation before doing anything
- closes all stack tabs and releases their stack buffers, then runs the existing memory compaction
- the next accepted frame starts a new stack and becomes its alignment reference frame

Supporting changes:

- **Stack mutations are serialized** with a `SemaphoreSlim` held across `StackItem` and across the reset. Previously only the primary tab was flagged with `Locked` while the OSC green/blue tabs were written unguarded, so a reset could have landed mid-frame.
- **Both renderers handle a tab with nothing stacked yet.** This also fixes a pre-existing path: when a freshly created tab's first frame was skipped for too few stars, `SelectedTab` was already pointing at it and `Render` would throw into the swallowing `catch`.

## Behaviour worth reviewing

- **The autosaved stack file is not deleted.** `stacks\Target-Filter.fits` keeps the pre-reset stack until the next accepted frame overwrites it. Deleting a user's exported file felt worse than leaving a stale one, but happy to change it.
- **Frames already queued survive the reset.** The channel is not flushed, so a frame captured before the click still gets stacked afterwards and becomes the new reference. Flushing is easy to add if "discard everything captured so far" is the preferred semantic.
- **Per-tab display settings reset** (stretch, black clipping, rotation, downsample), because the tabs are closed rather than emptied.
- The CHANGELOG entry is filed under `1.2.0.0` - renumber as you see fit, since CI takes the version from the tag.

## Testing

- `dotnet build nina.plugin.livestack.sln -c Release` - clean
- `dotnet test` - 18/18 pass
- Manually verified in N.I.N.A. 3.2.0.9001 on an OSC session: reset closes all four tabs (R/G/B + RGB) and the next frame starts a new stack. Icon choice and button width are cosmetic and were tuned afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
